### PR TITLE
bug: improve asdf install to reload shell

### DIFF
--- a/cli/install_dev_suit.sh
+++ b/cli/install_dev_suit.sh
@@ -77,6 +77,8 @@ main() {
   install_plugins_and_tools
 
   echo "All tools have been installed successfully!"
+  echo "Reloading shell to apply changes"
+  exec $SHELL
 }
 
 main

--- a/cli/install_dojo_dev_suit.sh
+++ b/cli/install_dojo_dev_suit.sh
@@ -77,6 +77,8 @@ main() {
   install_plugins_and_tools
 
   echo "All tools have been installed successfully!"
+  echo "Reloading shell to apply changes"
+  exec $SHELL
 }
 
 main


### PR DESCRIPTION
# 📝 Improve asdf install to reload shell 

## 🛠️ Issue
- Closes #176

## 📖 Description
This PR adds `exec $SHELL` to both scripts so that a new shell instance is created after the script, with this the user does not need to manually restart the shell or run the command `source /.zshrc`, therefore the script no longer needs manual intervention to run the `asdf` command.

## 🖼️ Screenshots (if applicable)
<img width="327" alt="Screenshot 2025-02-25 at 18 36 56" src="https://github.com/user-attachments/assets/505960a9-4322-4cc0-ad39-41bb7d6f8d75" />

## 📝 Additional Notes
Let me know if more changes are required.

