### PR TITLE
Enhancing String utility implimentations

### DIFF
--- a/examples/cairo/scripts/string_utility/src/lib.cairo
+++ b/examples/cairo/scripts/string_utility/src/lib.cairo
@@ -17,6 +17,15 @@ pub trait StringTrait {
     fn starts_with(self: @String, prefix: @String) -> bool;
     /// Check if a string ends with a suffix
     fn ends_with(self: @String, suffix: @String) -> bool;
+    /// Convert string to lowercase
+    fn to_lowercase(self: @String) -> String;
+    /// Convert string to uppercase
+    fn to_uppercase(self: @String) -> String;
+    /// Remove whitespace from start and end of string
+    fn trim(self: @String) -> String;
+    /// Get a portion of the string between start (inclusive) and end (exclusive) indices
+    fn substring(self: @String, start: usize, end: usize) -> String;
+    
 }
 
 impl StringImpl of StringTrait {
@@ -105,5 +114,193 @@ impl StringImpl of StringTrait {
             i += 1;
         }
     }
+
+    /// Convert string to lowercase
+    /// Arguments:
+    /// - self: The string to convert
+    /// Returns:
+    /// - A new string with all alphabetic characters converted to lowercase
+    fn to_lowercase(self: @String) -> String {
+        let mut result: ByteArray = "";
+        let mut i: usize = 0;
+        
+        loop {
+            if i >= self.len() {
+                break ();
+            }
+
+            // Get current byte
+            match self.data.at(i) {
+                Option::Some(byte) => {
+                    // Check if byte is uppercase letter (ASCII 65-90)
+                    if byte >= 65 && byte <= 90 {
+                        // Convert to lowercase by adding 32
+                        result.append_byte(byte + 32);
+                    } else {
+                        // Keep non-uppercase bytes unchanged
+                        result.append_byte(byte);
+                    }
+                },
+                Option::None => { break (); },
+            }
+
+            i += 1;
+        };
+
+        Self::new(result)
+    }
+
+    /// Convert string to uppercase
+    /// Arguments:
+    /// - self: The string to convert
+    /// Returns:
+    /// - A new string with all alphabetic characters converted to uppercase
+    fn to_uppercase(self: @String) -> String {
+        let mut result: ByteArray = "";
+        let mut i: usize = 0;
+        
+        loop {
+            if i >= self.len() {
+                break ();
+            }
+
+            // Get current byte
+            match self.data.at(i) {
+                Option::Some(byte) => {
+                    // Check if byte is lowercase letter (ASCII 97-122)
+                    if byte >= 97 && byte <= 122 {
+                        // Convert to uppercase by subtracting 32
+                        result.append_byte(byte - 32);
+                    } else {
+                        // Keep non-lowercase bytes unchanged
+                        result.append_byte(byte);
+                    }
+                },
+                Option::None => { break (); },
+            }
+
+            i += 1;
+        };
+
+        Self::new(result)
+    }
+
+    /// Remove whitespace from start and end of string
+    /// Arguments:
+    /// - self: The string to trim
+    /// Returns:
+    /// - A new string with leading and trailing whitespace removed
+    fn trim(self: @String) -> String {
+        // Handle empty string
+        if self.len() == 0 {
+            return Self::new("");
+        }
+
+        let mut start: usize = 0;
+        let mut end: usize = self.len();
+        
+        // Find first non-whitespace character
+        loop {
+            if start >= self.len() {
+                break ();
+            }
+            
+            match self.data.at(start) {
+                Option::Some(byte) => {
+                    // ASCII 32 is space, 9 is tab, 10 is newline, 13 is carriage return
+                    if byte != 32 && byte != 9 && byte != 10 && byte != 13 {
+                        break ();
+                    }
+                },
+                Option::None => { break (); },
+            }
+            
+            start += 1;
+        };
+
+        // If we reached the end, string is all whitespace
+        if start == self.len() {
+            return Self::new("");
+        }
+
+        // Find last non-whitespace character
+        loop {
+            if end == 0 {
+                break ();
+            }
+            
+            end -= 1;
+            
+            match self.data.at(end) {
+                Option::Some(byte) => {
+                    // ASCII 32 is space, 9 is tab, 10 is newline, 13 is carriage return
+                    if byte != 32 && byte != 9 && byte != 10 && byte != 13 {
+                        end += 1;
+                        break ();
+                    }
+                },
+                Option::None => { break (); },
+            }
+        };
+
+        // Create new string with characters between start and end
+        let mut result: ByteArray = "";
+        let mut i = start;
+        
+        loop {
+            if i >= end {
+                break ();
+            }
+            
+            match self.data.at(i) {
+                Option::Some(byte) => {
+                    result.append_byte(byte);
+                },
+                Option::None => { break (); },
+            }
+            
+            i += 1;
+        };
+
+        Self::new(result)
+    }
+
+    /// Get a portion of the string between start (inclusive) and end (exclusive) indices
+    /// Arguments:
+    /// - self: The source string
+    /// - start: Starting index (inclusive)
+    /// - end: Ending index (exclusive)
+    /// Returns:
+    /// - A new string containing the specified substring,
+    ///   or empty string if indices are invalid
+    fn substring(self: @String, start: usize, end: usize) -> String {
+        // Validate indices
+        if start >= self.len() || end > self.len() || start >= end {
+            return Self::new("");
+        }
+
+        let mut result: ByteArray = "";
+        let mut i = start;
+
+        // Copy characters from start to end
+        loop {
+            if i >= end {
+                break ();
+            }
+
+            match self.data.at(i) {
+                Option::Some(byte) => {
+                    result.append_byte(byte);
+                },
+                Option::None => { break (); },
+            }
+
+            i += 1;
+        };
+
+        Self::new(result)
+    }
+
+    
 }
 

--- a/examples/cairo/scripts/string_utility/src/lib.cairo
+++ b/examples/cairo/scripts/string_utility/src/lib.cairo
@@ -47,13 +47,6 @@ impl StringCompatibleString of StringCompatible<String> {
     }
 }
 
-// Implement for String Snapshot
-// impl StringCompatibleStringSnap of StringCompatible<@String> {
-//     fn to_bytes(self: @String) -> ByteArray {
-//         self.data.clone()
-//     }
-// }
-
 // Implement for ByteArray
 impl StringCompatibleByteArray of StringCompatible<ByteArray> {
     fn to_bytes(self: ByteArray) -> ByteArray {
@@ -61,12 +54,6 @@ impl StringCompatibleByteArray of StringCompatible<ByteArray> {
     }
 }
 
-// Implement for ByteArray Snapshot
-// impl StringCompatibleByteArraySnap of StringCompatible<@ByteArray> {
-//     fn to_bytes(self: @ByteArray) -> ByteArray {
-//         self.clone()
-//     }
-// }
 
 impl StringImpl of StringTrait {
     /// Create a new string

--- a/examples/cairo/scripts/string_utility/tests/test_contract.cairo
+++ b/examples/cairo/scripts/string_utility/tests/test_contract.cairo
@@ -127,3 +127,130 @@ fn test_multiple_string_manipulation() {
     assert(text.len() == 11, 'final length incorrect');
     assert(text.data == "Hello World", 'final content incorrect');
 }
+
+#[test]
+fn test_to_lowercase() {
+    // Test basic uppercase to lowercase
+    let string1 = StringTrait::new("HELLO");
+    let result1 = string1.to_lowercase();
+    assert(result1.data == "hello", 'basic lowercase failed');
+
+    // Test mixed case
+    let string2 = StringTrait::new("HeLLo WoRLD");
+    let result2 = string2.to_lowercase();
+    assert(result2.data == "hello world", 'mixed case failed');
+
+    // Test already lowercase
+    let string3 = StringTrait::new("hello");
+    let result3 = string3.to_lowercase();
+    assert(result3.data == "hello", 'already lowercase failed');
+
+    // Test with numbers and symbols
+    let string4 = StringTrait::new("HELLO123!@#");
+    let result4 = string4.to_lowercase();
+    assert(result4.data == "hello123!@#", 'special chars failed');
+
+    // Test empty string
+    let empty = StringTrait::new("");
+    let result5 = empty.to_lowercase();
+    assert(result5.data == "", 'empty string failed');
+}
+
+#[test]
+fn test_to_uppercase() {
+    // Test basic lowercase to uppercase
+    let string1 = StringTrait::new("hello");
+    let result1 = string1.to_uppercase();
+    assert(result1.data == "HELLO", 'basic uppercase failed');
+
+    // Test mixed case
+    let string2 = StringTrait::new("HeLLo WoRLD");
+    let result2 = string2.to_uppercase();
+    assert(result2.data == "HELLO WORLD", 'mixed case failed');
+
+    // Test already uppercase
+    let string3 = StringTrait::new("HELLO");
+    let result3 = string3.to_uppercase();
+    assert(result3.data == "HELLO", 'already uppercase failed');
+
+    // Test with numbers and symbols
+    let string4 = StringTrait::new("hello123!@#");
+    let result4 = string4.to_uppercase();
+    assert(result4.data == "HELLO123!@#", 'special chars failed');
+
+    // Test empty string
+    let empty = StringTrait::new("");
+    let result5 = empty.to_uppercase();
+    assert(result5.data == "", 'empty string failed');
+}
+
+#[test]
+fn test_trim() {
+    // Test basic space trimming
+    let string1 = StringTrait::new("  hello  ");
+    let result1 = string1.trim();
+    assert(result1.data == "hello", 'basic trim failed');
+
+    // Test with tabs and newlines
+    let string2 = StringTrait::new("\t\n hello world \r\n");
+    let result2 = string2.trim();
+    assert(result2.data == "hello world", 'mixed whitespace failed');
+
+    // Test with no trim needed
+    let string3 = StringTrait::new("hello");
+    let result3 = string3.trim();
+    assert(result3.data == "hello", 'no trim needed failed');
+
+    // Test with internal spaces
+    let string4 = StringTrait::new("   hello   world   ");
+    let result4 = string4.trim();
+    assert(result4.data == "hello   world", 'internal spaces failed');
+
+    // Test all whitespace string
+    let string5 = StringTrait::new("   \t\n\r   ");
+    let result5 = string5.trim();
+    assert(result5.data == "", 'all whitespace failed');
+
+    // Test empty string
+    let empty = StringTrait::new("");
+    let result6 = empty.trim();
+    assert(result6.data == "", 'empty string failed');
+}
+
+#[test]
+fn test_substring() {
+    let test_string = StringTrait::new("Hello World");
+
+    // Test basic substring
+    let result1 = test_string.substring(6, 11);
+    assert(result1.data == "World", 'basic substring failed');
+
+    // Test from start
+    let result2 = test_string.substring(0, 5);
+    assert(result2.data == "Hello", 'start substring failed');
+
+    // Test single character
+    let result3 = test_string.substring(0, 1);
+    assert(result3.data == "H", 'single char failed');
+
+    // Test invalid start index
+    let result4 = test_string.substring(12, 15);
+    assert(result4.data == "", 'invalid start failed');
+
+    // Test invalid end index
+    let result5 = test_string.substring(0, 15);
+    assert(result5.data == "", 'invalid end failed');
+
+    // Test start >= end
+    let result6 = test_string.substring(5, 2);
+    assert(result6.data == "", 'invalid range failed');
+
+    // Test empty string
+    let empty = StringTrait::new("");
+    let result7 = empty.substring(0, 1);
+    assert(result7.data == "", 'empty string failed');
+
+    // Test middle substring
+    let result8 = test_string.substring(3, 8);
+    assert(result8.data == "lo Wo", 'middle substring failed');
+}

--- a/examples/cairo/scripts/string_utility/tests/test_contract.cairo
+++ b/examples/cairo/scripts/string_utility/tests/test_contract.cairo
@@ -1,4 +1,5 @@
 use string_utility::{StringTrait};
+use core::byte_array::ByteArray;
 
 #[test]
 fn test_new() {
@@ -253,4 +254,82 @@ fn test_substring() {
     // Test middle substring
     let result8 = test_string.substring(3, 8);
     assert(result8.data == "lo Wo", 'middle substring failed');
+}
+
+#[test]
+fn test_generic_replace() {
+    let sentence = StringTrait::new("This is an old banana.");
+
+    // Test with both String arguments
+    let target = StringTrait::new("old");
+    let replacement = StringTrait::new("amazing");
+    let result1 = sentence.replace(target, replacement);
+    assert(result1.data == "This is an amazing banana.", 'str-str replace failed');
+
+    // Test with ByteArray and String
+    let target: ByteArray = "old";
+    let replacement = StringTrait::new("amazing");
+    let result2 = sentence.replace(target, replacement);
+    assert(result2.data == "This is an amazing banana.", 'bytes-str replace failed');
+
+    // Test with String and ByteArray
+    let target = StringTrait::new("old");
+    let replacement: ByteArray = "amazing";
+    let result3 = sentence.replace(target, replacement);
+    assert(result3.data == "This is an amazing banana.", 'str-bytes replace failed');
+
+    // Test with both ByteArray arguments
+    let target: ByteArray = "old";
+    let replacement: ByteArray = "amazing";
+    let result4 = sentence.replace(target, replacement);
+    assert(result4.data == "This is an amazing banana.", 'bytes-bytes replace failed');
+}
+
+#[test]
+fn test_generic_contains() {
+    let sentence = StringTrait::new("This is an old banana.");
+
+    // Test with String pattern
+    let pattern = StringTrait::new("old");
+    assert(sentence.contains(pattern), 'str contains failed');
+
+    // Test with ByteArray pattern
+    let pattern: ByteArray = "old";
+    assert(sentence.contains(pattern), 'bytes contains failed');
+
+    // Test non-matching String pattern
+    let non_match = StringTrait::new("new");
+    assert(!sentence.contains(non_match), 'str non-match failed');
+
+    // Test non-matching ByteArray pattern
+    let non_match: ByteArray = "new";
+    assert(!sentence.contains(non_match), 'bytes non-match failed');
+}
+
+#[test]
+fn test_generic_edge_cases() {
+    let sentence = StringTrait::new("Hello World");
+    let empty_str = StringTrait::new("");
+    let empty: ByteArray = "";
+
+    // Empty string and pattern combination
+    assert(empty_str.contains(empty), 'empty-empty failed');
+
+    // Replace with empty string/pattern
+    let empty_str = StringTrait::new("");
+    let empty: ByteArray = "";
+    let result1 = sentence.replace(empty_str, empty);
+    assert(result1.data == sentence.data, 'empty replace failed');
+
+    // Replace with longer/shorter replacements
+    let target: ByteArray = "o";
+    let replacement: ByteArray = "oo";
+    let result2 = sentence.replace(target, replacement);
+    assert(result2.data == "Helloo Woorld", 'longer replace failed');
+
+    // Case sensitivity
+    let word: ByteArray = "hello";
+    let word_str = StringTrait::new("hello");
+    assert(!sentence.contains(word), 'case sensitivity bytes failed');
+    assert(!sentence.contains(word_str), 'case sensitivity str failed');
 }


### PR DESCRIPTION
# 📝 String Utility Enhancement

## 🛠️ Issue
- Closes #164 

## 📖 Description
Extended upon the existing set of utilities enabled for the custom 'String' struct. Added well-documented utilities for further String operations including:
- `to_lowercase`
- `to_uppercase`
- `trim`
- `substring`
- `replace`
- `contains`

Added and successfully validated sufficient test cases for each new String utility implementation.
