### PR TITLE
[FIX]: Update string utility examples

### DIFF
--- a/examples/cairo/scripts/utility_examples/string_utils/.tool-versions
+++ b/examples/cairo/scripts/utility_examples/string_utils/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.11.0
+scarb 2.9.2
 starknet-foundry 0.34.0

--- a/examples/cairo/scripts/utility_examples/string_utils/src/main.cairo
+++ b/examples/cairo/scripts/utility_examples/string_utils/src/main.cairo
@@ -1,5 +1,5 @@
 use core::byte_array::ByteArray;
-use string_utility::{String, StringTrait};
+use string_utility::string_utility::{String, StringTrait};
 
 fn main() {
     // Example 1: Create a new string and display its length.

--- a/examples/cairo/scripts/utility_examples/string_utils/src/tests/test_main.cairo
+++ b/examples/cairo/scripts/utility_examples/string_utils/src/tests/test_main.cairo
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test_main {
-    use string_utility::{String, StringTrait};
+    use string_utility::string_utility::{String, StringTrait};
 
 
     #[test]


### PR DESCRIPTION
# 📝 [FIX]: Update string utility examples 

- Fixed an error in the string utility examples (import path and adjust tool versions).

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/dd6645f5-639d-4873-9d96-164fc2c14b37" />
